### PR TITLE
Allow hostname validation

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -35,17 +35,18 @@ class Recaptcha2
       uri: @apiEndpoint
       form: body
 
-  validate: (response, remoteip)->
+  validate: (response, remoteip, hostnameValidator)->
     new Promise (resolve, reject)=>
       return reject ['missing-input-response']  if not response
       options = @getRequestOptions {response, remoteip}
       request options, (error, response, body)->
         return reject ['request-error', error.toString()]  if error
+        return reject ['invalid-hostname'] if not hostnameValidator(body.hostname) if hostnameValidator
         return resolve true  if body.success is true
         reject body['error-codes']
 
-  validateRequest: (req, ip)->
-    return @validate req.body['g-recaptcha-response'], ip
+  validateRequest: (req, ip, hostnameValidator)->
+    return @validate req.body['g-recaptcha-response'], ip, hostnameValidator
 
   translateErrors: (errorCodes)->
     return (ERRORS[errorCodes] or errorCodes)  if not Array.isArray errorCodes

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@
       });
     };
 
-    Recaptcha2.prototype.validate = function(response, remoteip) {
+    Recaptcha2.prototype.validate = function(response, remoteip, hostnameValidator) {
       return new Promise((function(_this) {
         return function(resolve, reject) {
           var options;
@@ -59,6 +59,11 @@
             if (error) {
               return reject(['request-error', error.toString()]);
             }
+            if (hostnameValidator) {
+              if (!hostnameValidator(body.hostname)) {
+                return reject(['invalid-hostname']);
+              }
+            }
             if (body.success === true) {
               return resolve(true);
             }
@@ -68,8 +73,8 @@
       })(this));
     };
 
-    Recaptcha2.prototype.validateRequest = function(req, ip) {
-      return this.validate(req.body['g-recaptcha-response'], ip);
+    Recaptcha2.prototype.validateRequest = function(req, ip, hostnameValidator) {
+      return this.validate(req.body['g-recaptcha-response'], ip, hostnameValidator);
     };
 
     Recaptcha2.prototype.translateErrors = function(errorCodes) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     {
       "name": "Dumitru Glavan",
       "email": "contact@dumitruglavan.com"
+    },
+    {
+      "name": "Felippe Nardi",
+      "email": "felippe.recaptcha2@nardi.me"
     }
   ]
 }

--- a/tests/recaptcha2.coffee
+++ b/tests/recaptcha2.coffee
@@ -8,14 +8,14 @@ GOOGLE_CAPTCHA_ENDPOINT = "https://www.google.com/recaptcha/api/siteverify"
 RECAPTCHA_RESPONSE_OK =
   "success": true
   "challenge_ts": Date.now()
-  "hostname": "127.0.0.1"
+  "hostname": "localhost"
   "error-codes": [
     "invalid-input-response"
   ]
 RECAPTCHA_RESPONSE_ERROR =
   "success": false
   "challenge_ts": Date.now()
-  "hostname": "127.0.0.1"
+  "hostname": "localhost"
   "error-codes": [
     "invalid-input-response",
     "invalid-input-secret"
@@ -23,13 +23,13 @@ RECAPTCHA_RESPONSE_ERROR =
 
 
 describe "recaptcha2", ->
-  
+
   it "has a default config", ->
     recaptcha2.config.should.eql siteKey: "public_site_key", secretKey: "secret_key", ssl: true
-  
+
   it "has a default secure endpoint", ->
     recaptcha2.apiEndpoint.should.eql GOOGLE_CAPTCHA_ENDPOINT
-  
+
   it "has an unsecure endpoint when ssl disabled", ->
     unsecureRecaptcha2 = new Recaptcha2 siteKey: "public_site_key", secretKey: "secret_key", ssl: false
     unsecureRecaptcha2.apiEndpoint.should.eql GOOGLE_CAPTCHA_ENDPOINT.replace("https", "http")
@@ -46,6 +46,43 @@ describe "recaptcha2", ->
           done()
         .catch (error)->
           should.not.exist error
+
+    describe "when there is a valid hostname and frontend captcha response", ->
+      it "resolves as successful", (done)->
+        postData = response: "valid_captcha_response", remoteip: "127.0.0.1", secret: "secret_key"
+        hostnameValidator = (hostname) -> return true if hostname is "localhost"
+        scope = nock("https://www.google.com")
+        .post("/recaptcha/api/siteverify", postData).reply 200, RECAPTCHA_RESPONSE_OK
+        recaptcha2.validate("valid_captcha_response", "127.0.0.1", hostnameValidator)
+        .then (response)->
+          response.should.eql true
+          done()
+        .catch (error)->
+          should.not.exist error
+
+    describe "when there is an invalid hostname", ->
+      it "rejects", (done)->
+        postData = response: "valid_captcha_response", remoteip: "127.0.0.1", secret: "secret_key"
+        hostnameValidator = (hostname) -> return true if hostname is "example.domain"
+        scope = nock("https://www.google.com")
+        .post("/recaptcha/api/siteverify", postData).reply 200, RECAPTCHA_RESPONSE_OK
+        recaptcha2.validate("valid_captcha_response", "127.0.0.1", hostnameValidator)
+        .catch (errors)->
+          should.exist errors
+          errors.should.eql ['invalid-hostname']
+          done()
+
+    describe "when there is an invalid hostname but no remote ip is passed", ->
+      it "rejects", (done)->
+        postData = response: "valid_captcha_response", secret: "secret_key"
+        hostnameValidator = (hostname) -> return true if hostname is "example.domain"
+        scope = nock("https://www.google.com")
+        .post("/recaptcha/api/siteverify", postData).reply 200, RECAPTCHA_RESPONSE_OK
+        recaptcha2.validate("valid_captcha_response", null, hostnameValidator)
+        .catch (errors)->
+          should.exist errors
+          errors.should.eql ['invalid-hostname']
+          done()
 
     describe "when there is an empty frontend captcha response", ->
       it "rejects", (done)->
@@ -90,9 +127,21 @@ describe "recaptcha2", ->
         .catch (error)->
           should.not.exist error
 
+    describe "when there is a valid frontend captcha response but an invalid hostname", ->
+      it "resolves as successful", (done)->
+        postData = response: "valid_captcha_response", remoteip: "127.0.0.1", secret: "secret_key"
+        hostnameValidator = (hostname) -> return true if hostname is "example.domain"
+        scope = nock("https://www.google.com")
+        .post("/recaptcha/api/siteverify", postData).reply 200, RECAPTCHA_RESPONSE_OK
+        recaptcha2.validateRequest({body: {'g-recaptcha-response': "valid_captcha_response"}}, "127.0.0.1", hostnameValidator)
+        .catch (errors)->
+          should.exist errors
+          errors.should.eql ['invalid-hostname']
+          done()
+
   describe "getRequestOptions", ->
     body = response: "g-recaptcha_frontend_response", remoteip: "origin_ip"
-    
+
     it "returns the request options with the given form body", ->
       recaptcha2.getRequestOptions(body).should.eql
         uri: GOOGLE_CAPTCHA_ENDPOINT
@@ -104,10 +153,10 @@ describe "recaptcha2", ->
           secret: "secret_key"
 
   describe "translateErrors", ->
-    describe "when the given error is a string", ->  
+    describe "when the given error is a string", ->
       it "returns a verbose string error", ->
         recaptcha2.translateErrors("request-error").should.eql "Api request failed."
-    
+
     describe "when the given error is an array", ->
       it "returns a verbose errors array", ->
         errors = [


### PR DESCRIPTION
## Summary
In more complex applications setups, a static list of valid domains may not suffice. You might want to do a server-side hostname check as suggested by Google:
> [...], if your domain or package name list is extremely long, fluid, or unknown, we give you the option to turn off the domain or package name checking on reCAPTCHA's end, and instead check on your server.
> Source: https://developers.google.com/recaptcha/docs/domain_validation

This PR adds the ability to disable "Domain Name Validation" on reCaptcha Admin Console and do a hostname validation manually.

## Implementation
This PR adds a third parameter for the functions `.validate` and `.validateRequest`: a hostname validation function, that receives the hostname and should return `true` if it is valid, and `false` otherwise.

This modification *should be backward compatible* with previous versions and cause no side-effects. If the new third parameter is not used, it is just ignored.

It uses the `hostname` property that comes in the body as stated in the docs: https://developers.google.com/recaptcha/docs/verify#api-response